### PR TITLE
Made the header name comparison case insensitive

### DIFF
--- a/log.js
+++ b/log.js
@@ -8,7 +8,7 @@ var ChromePhpLogger = function()
     /**
      * @var string
      */
-    var HEADER_NAME = "X-ChromePhp-Data";
+    var HEADER_NAME = "x-chromephp-data";
 
     /**
      * @var object
@@ -173,7 +173,7 @@ var ChromePhpLogger = function()
             header = '';
 
         for (var i = 0; i < headers.length; ++i) {
-            if (headers[i].name == HEADER_NAME) {
+            if (headers[i].name.toLowerCase() == HEADER_NAME) {
                 header = headers[i].value;
                 match = true;
                 break;


### PR DESCRIPTION
HTTP header names are case insensitive. However, the comparison done in the extension is currently case sensitive. This breaks things if the header is not sent with the exact same case. And for instance, the Symfony2 HttpFoundation component sends all headers as lowercase.
This will fix the use of the extension with Symfony2 (see symfony/symfony#3477)
