### PR TITLE
Delay updating client until onCompleted event

### DIFF
--- a/background.html
+++ b/background.html
@@ -96,7 +96,7 @@
             chrome.tabs.onSelectionChanged.addListener(_handleTabUpdate);
             chrome.tabs.onUpdated.addListener(_handleTabUpdate);
 
-            chrome.webRequest.onResponseStarted.addListener(function(details) {
+            chrome.webRequest.onCompleted.addListener(function(details) {
                 chrome.tabs.getSelected(null, function(tab) {
                     chrome.tabs.sendRequest(tab.id, {name: "header_update", details: details});
                 });


### PR DESCRIPTION
Previously the client received log data after the `onResponseStarted` event, and the extension logged it - but chrome clears the console shortly after.

This patch instead uses the last web request event, `onCompleted`, to print log statements after the console has been cleared.

fixes #4

Chrome web request info
https://developer.chrome.com/extensions/webRequest.html#life_cycle
