### PR TITLE
Fix race condition in Chrome 28

### DIFF
--- a/log.js
+++ b/log.js
@@ -235,6 +235,17 @@
             }
             return _initStorage();
         });
+        chrome.extension.sendMessage("ready", function(queuedRequests) {
+            if(queuedRequests){
+                for(var i=0;i<queuedRequests.length;i++){
+                    if(use_queue){
+                        queue.push(queuedRequests[i]);
+                    } else {
+                        _process(queuedRequests[i]);
+                    }
+                }
+            }
+        });
     }
 
     _init();


### PR DESCRIPTION
As discussed in #22, a lot of ChromeLogger messages seem get lost in Chrome 28.  

As far as I can tell, Chrome 28 will often capture WebRequests and fire 'onResponseStarted' before our target page's `log.js` content script has had enough time to bind a listener to the extension's `header_update` messages.  This PR captures any "lost" `header_update` messages that don't receive a `done` response, and queues them up until the content script is ready for them.
