### PR TITLE
Bugfixes and refactoring

### DIFF
--- a/chromelogger-options.js
+++ b/chromelogger-options.js
@@ -3,9 +3,9 @@
     'use strict';
 
     var defaults = {
-        show_upgrade_messages: true,
-        show_line_numbers: false,
-        color1: "#888",
+        show_upgrade_messages: 'true',
+        show_line_numbers: 'false',
+        color1: "#888888",
         color2: "#0563ad"
     };
 
@@ -21,40 +21,23 @@
         setTimeout(function() {
             info_div.style.display = "none";
         }, 2500);
-
     }
 
     function saveOptions(e) {
         e.preventDefault();
 
         getInputs().forEach(function(input) {
-            if (input.type == 'text') {
-                localStorage[input.name] = _getColorFromValue(input.value);
-                return;
-            }
-            localStorage[input.name] = input.checked;
+            localStorage[input.name] = input.type == 'checkbox' ? input.checked : input.value;
         });
 
         showMessage('your settings have been saved');
     }
 
-    function _getColorFromValue(value) {
-        if (value.indexOf('#') === 0) {
-            return value;
-        }
-
-        var colors = ['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'pink', 'white', 'black'];
-        if (colors.indexOf(value) !== -1) {
-            return value;
-        }
-
-        return '#' + value;
-    }
-
     function _setInputValue(input, value) {
-        input.value = value.indexOf('#') === 0 ? value.substring(1) : value;
-
-        input.parentNode.querySelector('.swatch').style.background = _getColorFromValue(value);
+        if (input.type === 'color' && !/#\d{6}/.test(value)) {
+            value = defaults[input.name];
+        }
+        input.value = value;
     }
 
     function restoreDefaults(e) {
@@ -65,35 +48,27 @@
 
             localStorage[input.name] = value;
 
-            if (input.type == 'text') {
+            if (input.type == 'checkbox') {
+                input.checked = value;
+            } else {
                 _setInputValue(input, value);
-                return;
             }
-
-            input.checked = value;
         });
 
         showMessage('settings have been restored to the defaults');
     }
 
-    function _handleColorChange(e) {
-        if (e.target.tagName === 'INPUT' && e.target.type == 'text') {
-            _setInputValue(e.target, e.target.value);
-        }
-    }
-
     function init() {
         getInputs().forEach(function(input) {
-            if (input.type == 'text') {
+            if (input.type == 'checkbox') {
+                input.checked = input.name in localStorage ? localStorage[input.name] === "true" : defaults[input.name];
+            } else {
                 _setInputValue(input, input.name in localStorage ? localStorage[input.name] : defaults[input.name]);
-                return;
             }
-            input.checked = input.name in localStorage ? localStorage[input.name] === "true" : defaults[input.name];
         });
 
         document.getElementById('save').addEventListener('click', saveOptions, false);
         document.getElementById('restore').addEventListener('click', restoreDefaults, false);
-        document.addEventListener('input', _handleColorChange, false);
     }
 
     document.addEventListener('DOMContentLoaded', init, false);

--- a/options.html
+++ b/options.html
@@ -107,13 +107,13 @@
 
             <label>
                 color 1:
-                <input type="text" name="color1" value=""> <span class="swatch"></span>
+                <input type="color" name="color1" value="">
             </label>
             <p class="info">color used for line numbers</p>
 
             <label>
                 color 2:
-                <input type="text" name="color2" value=""> <span class="swatch"></span>
+                <input type="color" name="color2" value="">
             </label>
             <p class="info">color used for class names</p>
 


### PR DESCRIPTION
Use chrome's built in colorpicker for choosing colors on options page. - The input type 'color' has been available since Chrome 20 so why not use it?

Identify pages by host rather than by 'topLevelDomain' - The old "Top Level Domain" code was actually getting the top and second level domain. This can be not enough (in case of `example.co.jp`) or too much (in case of `localhost`) and it also didn't account for port which might be important. So now, active sites are identified by `host` which means their full domain name and port if different from :80. 

Use appropriate tab events - we may need to take action on any of: `onCreated`, `onActivated`, or `onUpdated`. `onSelectionChanged` is deprecated.

Various other fixes and refactoring - for example, the logic for when to push details to queuedRequests needs to be based on the url (host actually) of the tab, not just the tab id. 

These fixes should solve the forgetfulness issues that have been discussed in #44 and #39
