### PR TITLE
add header to outgoing requests; closes #8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
     "permissions":
     [
         "webRequest",
+        "webRequestBlocking",
         "tabs",
         "http://*/*",
         "https://*/*"


### PR DESCRIPTION
Adds an `X-Chromelogger: 1` header to outgoing requests, for tabs with ChromeLogger enabled.

Closes #8 
